### PR TITLE
recipe_uuid is mandatory

### DIFF
--- a/src/commands/start-instance.yml
+++ b/src/commands/start-instance.yml
@@ -3,7 +3,6 @@ description: >
 parameters:
   recipe_uuid:
     type: string
-    default: ""
     description: |
       Instance recipe to use. Recipes can be listed with command line 'gmsaas recipes list',
       or check https://support.genymotion.com/hc/en-us/articles/360007473658-Supported-Android-devices-templates-for-Genymotion-Cloud-SaaS


### PR DESCRIPTION
Make recipe_uuid mandatory in start-instance command