### PR TITLE
Support Genymotion SaaS api token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 # release must exist.);
 orbs:
   genymotion-saas: genymotion/genymotion-saas@<<pipeline.parameters.dev-orb-version>>
-  orb-tools: circleci/orb-tools@9.0
+  orb-tools: circleci/orb-tools@10.0
 
 # Pipeline parameters
 parameters:
@@ -90,7 +90,7 @@ workflows:
   # It is meant to be triggered by the "trigger-integration-tests-workflow"
   # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
   integration-tests_prod-release:
-    #when: << pipeline.parameters.run-integration-tests >>
+    when: << pipeline.parameters.run-integration-tests >>
     jobs:
       # your integration test jobs go here: essentially, run all your orb's
       # jobs and commands to ensure they behave as expected. or, run other

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,7 @@ jobs:
     steps:
       - checkout
       - genymotion-saas/setup:
-          email: GMCLOUD_SAAS_EMAIL
-          password: GMCLOUD_SAAS_PASSWORD
+          api_token: GMCLOUD_SAAS_APITOKEN
       - genymotion-saas/start-instance:
           recipe_uuid: "f34de94f-1e85-4d61-9b0d-c47968bc156c"
           adb_serial_port: 12345
@@ -91,7 +90,7 @@ workflows:
   # It is meant to be triggered by the "trigger-integration-tests-workflow"
   # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
   integration-tests_prod-release:
-    when: << pipeline.parameters.run-integration-tests >>
+    #when: << pipeline.parameters.run-integration-tests >>
     jobs:
       # your integration test jobs go here: essentially, run all your orb's
       # jobs and commands to ensure they behave as expected. or, run other

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -1,14 +1,10 @@
 description: >
   Download gmsaas cli and authenticate the user.
 parameters:
-  email:
+  api_token:
     type: env_var_name
-    default: GMCLOUD_SAAS_EMAIL
-    description: "Email of your Genymotion Cloud SaaS account. Set this to the name of the environment variable: GMCLOUD_SAAS_EMAIL."
-  password:
-    type: env_var_name
-    default: GMCLOUD_SAAS_PASSWORD
-    description: "Password of your Genymotion Cloud SaaS account. Set this to the name of the environment variable: GMCLOUD_SAAS_PASSWORD."
+    default: GMCLOUD_SAAS_APITOKEN
+    description: "API Token of your Genymotion Cloud SaaS account. Set this to the name of the environment variable: GMCLOUD_SAAS_APITOKEN."
   gmsaas_version:
     type: string
     default: ""
@@ -34,4 +30,6 @@ steps:
         gmsaas config set android-sdk-path $ANDROID_HOME
   - run:
       name: Authenticate
-      command: gmsaas auth login ${<< parameters.email >>} ${<< parameters.password >>}
+      command: |
+        gmsaas auth token ${<< parameters.api_token >>}
+        gmsaas doctor

--- a/src/examples/override-credentials.yml
+++ b/src/examples/override-credentials.yml
@@ -1,7 +1,7 @@
 description: >
    How to :
-    - Configure your Genymotion Cloud SaaS account by overriding default credentials (GMCLOUD_SAAS_EMAIL & GMCLOUD_SAAS_PASSWORD environment variables).
-      In this example, you can use EMAIL/PASSWORD credentials which have been set as environment variables.
+    - Configure your Genymotion Cloud SaaS account by overriding default credentials (GMCLOUD_SAAS_APITOKEN environment variables).
+      In this example, you can use API TOKEN credentials which have been set as environment variables.
       Credentials must be set as environment variables.
    - Start Android instance, test your app and stop instance.
 usage:
@@ -15,8 +15,7 @@ usage:
       executor: genymotion-saas/default
       steps:
         - genymotion-saas/setup:
-            email: EMAIL
-            password: PASSWORD
+            api_token: API_TOKEN
         - genymotion-saas/start-instance:
             recipe_uuid: "" # Mandatory: Retrieve the recipe uuid using 'gmsaas recipes list' command line or check https://support.genymotion.com/hc/en-us/articles/360007473658-Supported-Android-devices-templates-for-Genymotion-Cloud-SaaS for a comprehensive list of all currently available recipes UUIDs.
         - run: echo "Run your tests here"

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,11 +4,11 @@ description: >
 
 parameters:
   tag:
-    default: api-29
+    default: 2024.11.1
     description: >
       Pick a specific circleci/android image tag:
       https://hub.docker.com/r/circleci/android/tags
     type: string
 
 docker:
-  - image: 'circleci/android:<<parameters.tag>>'
+  - image: 'cimg/android:<<parameters.tag>>'

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,13 +1,13 @@
 description: >
   Android SDK tools are required for this orb, so we will use Circle CI image for Android:
-  https://hub.docker.com/r/circleci/android
+  https://hub.docker.com/r/cimg/android/tags
 
 parameters:
   tag:
     default: 2024.11.1
     description: >
-      Pick a specific circleci/android image tag:
-      https://hub.docker.com/r/circleci/android/tags
+      Pick a specific android image tag:
+      https://hub.docker.com/r/cimg/android/tags
     type: string
 
 docker:

--- a/src/jobs/run_tests.yml
+++ b/src/jobs/run_tests.yml
@@ -6,7 +6,7 @@ parameters:
     default: 2024.11.1
     description: >
       Pick a specific circleci/android image tag:
-      https://hub.docker.com/r/circleci/android/tags
+      https://hub.docker.com/r/cimg/android/tags
 
   recipe_uuid:
     type: string

--- a/src/jobs/run_tests.yml
+++ b/src/jobs/run_tests.yml
@@ -3,7 +3,7 @@ description: Start Android instance, test your app and stop instance.
 parameters:
   tag:
     type: string
-    default: api-29
+    default: 2024.11.1
     description: >
       Pick a specific circleci/android image tag:
       https://hub.docker.com/r/circleci/android/tags


### PR DESCRIPTION
**Breaking Changes**

-  Deprecated credentials: The email/password authentication method is no longer supported.
-  API Token required: Connecting to Genymotion SaaS services now requires an API Token.
        New environment variable required:
            You must set an environment variable named GMCLOUD_SAAS_APITOKEN containing your Genymotion SaaS API Token.
            [Guide to generate an API Token.](https://docs.genymotion.com/saas/10_Public_HTTP_API/#generate-and-manage-api-tokens) 